### PR TITLE
Replace MathJax link with https one

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -29,6 +29,6 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>

--- a/_site/index.html
+++ b/_site/index.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/learning_goals.html
+++ b/_site/learning_goals.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/notes/c.html
+++ b/_site/notes/c.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/notes/connect.html
+++ b/_site/notes/connect.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/notes/index.html
+++ b/_site/notes/index.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/notes/linux.html
+++ b/_site/notes/linux.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/projects/index.html
+++ b/_site/projects/index.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/projects/project0.html
+++ b/_site/projects/project0.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/projects/project1.html
+++ b/_site/projects/project1.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/reveal.js/test/examples/math.html
+++ b/_site/reveal.js/test/examples/math.html
@@ -169,7 +169,7 @@
 				transition: 'linear',
 
 				math: {
-					// mathjax: 'http://cdn.mathjax.org/mathjax/latest/MathJax.js',
+					// mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js',
 					config: 'TeX-AMS_HTML-full'
 				},
 

--- a/_site/syllabus.html
+++ b/_site/syllabus.html
@@ -33,7 +33,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/_site/update/2016/08/16/welcome-to-jekyll.html
+++ b/_site/update/2016/08/16/welcome-to-jekyll.html
@@ -32,7 +32,7 @@
   });
 </script>
 <script type="text/javascript"
-        src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+        src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 </head>
 

--- a/reveal.js/test/examples/math.html
+++ b/reveal.js/test/examples/math.html
@@ -169,7 +169,7 @@
 				transition: 'linear',
 
 				math: {
-					// mathjax: 'http://cdn.mathjax.org/mathjax/latest/MathJax.js',
+					// mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js',
 					config: 'TeX-AMS_HTML-full'
 				},
 


### PR DESCRIPTION
Dear Prof. Freeman,
Reference to JavaScript files hosted on http sites on an https site (your course website) will result in non-https resources being blocked by some modern broswers, which means the MathJax included in the page won't be working in Chrome, etc. This commit replaces all HTTP reference to MathJax Library with HTTPS version.
